### PR TITLE
added --target-min-width and --target-max-width 

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,2 @@
+[run]
+omit = *test*

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -26,7 +26,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install flake8 pytest wheel
+        pip install flake8 pytest-cov wheel
         if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
     - name: Compile DCR Binaries
       run: |

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -42,9 +42,11 @@ jobs:
         flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
     - name: Test with pytest
       run: |
-        pytest
-    - name: Coveralls GitHub Action
-      uses: coverallsapp/github-action@v1.1.2
+        pytest --cov=goodman_pipeline
+
+    - uses: codecov/codecov-action@v1
       with:
-        github-token: ${{ secrets.github_token }}
+        token: ${{ secrets.CODECOV_TOKEN }} # not required for public repos
+        fail_ci_if_error: true # optional (default = false)
+
 

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -45,4 +45,6 @@ jobs:
         pytest
     - name: Coveralls GitHub Action
       uses: coverallsapp/github-action@v1.1.2
+      with:
+        github-token: ${{ secrets.github_token }}
 

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -43,3 +43,6 @@ jobs:
     - name: Test with pytest
       run: |
         pytest
+    - name: Coveralls GitHub Action
+      uses: coverallsapp/github-action@v1.1.2
+

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Goodman High Throughput Spectrograph Data Reduction Pipeline
 
 ![Goodman Pipeline](https://github.com/soar-telescope/goodman_pipeline/workflows/Goodman%20Pipeline/badge.svg?branch=master)
-[![Coverage Status](https://coveralls.io/repos/github/soar-telescope/goodman_pipeline/badge.svg?branch=master)](https://coveralls.io/github/soar-telescope/goodman_pipeline?branch=master)
+[![codecov](https://codecov.io/gh/soar-telescope/goodman_pipeline/branch/main/graph/badge.svg)](https://codecov.io/gh/soar-telescope/goodman_pipeline)
 [![Documentation Status](https://readthedocs.org/projects/goodman/badge/?version=latest)](http://goodman.readthedocs.io/en/latest/?badge=latest)
 [![pypi](https://img.shields.io/pypi/v/goodman_pipeline.svg?style=flat)](https://pypi.org/project/goodman-pipeline/)
 [![astropy](http://img.shields.io/badge/powered%20by-AstroPy-orange.svg?style=flat)](http://www.astropy.org/)

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 The Goodman High Throughput Spectrograph (Goodman HTS) Data-Reduction Pipeline
 is the SOAR Telescope's official data reduction pipeline for *Goodman HTS*.
 
-It has been fully developed in Python 3.5 and uses mostly astropy affiliated packages
+It has been fully developed in Python and uses mostly astropy affiliated packages
 with the exception of [dcr](http://users.camk.edu.pl/pych/DCR/) which is an external tool
 that does cosmic ray identification and correction. The reason for using it
 instead of LACosmic is that it works very well for spectroscopic data and the
@@ -43,7 +43,7 @@ open a [new Issue](https://github.com/soar-telescope/goodman_pipeline/issues/new
 
 ## Development Team
 
-- [Simón Torres](https://github.com/simontorres) (SOAR Telescope Data Analyst - main code developer)
+- [Simón Torres](https://github.com/simontorres) (NOIRLab Software Engineer - main code developer)
 - [César Briceño](https://github.com/cbaorion) (SOAR Telescope Scientist - team lead)
 - [Bruno Quint](https://github.com/b1quint) (Brazil Support Astronomer - code development adviser)
 

--- a/docs/_file_prefixes.rst
+++ b/docs/_file_prefixes.rst
@@ -3,11 +3,17 @@
 File Prefixes
 *************
 
+.. note::
+
+  Overscan is no longer performed by default. Since it caused a double bias level substraction.
+  Fixed since release :ref:`v1.3.3`.
+
+
 There are several ways one can do this but we selected adding prefixes to the
 file name because is easier to add and also easy to filter using a terminal,
 for instance.
 
-  ``ls cfzsto*fits``
+  ``ls cfzst*fits``
 
 or in python
 
@@ -15,7 +21,7 @@ or in python
 
   import glob
 
-  file_list = glob.glob('cfzsto*fits')
+  file_list = glob.glob('cfzst*fits')
 
 So what does all those letter mean? Here is a table to explain it.
 

--- a/docs/_running_redspec.rst
+++ b/docs/_running_redspec.rst
@@ -28,14 +28,25 @@ behavior for every user or science case, we have implemented a set of
 - ``--proc-path <path>`` Folder were processed data will be stored. Default
   is *current working directory*.
 - ``--search-pattern <pattern>`` Prefix for picking up files. Default
-  ``cfzsto``. See :ref:`file-prefixes`.
+  ``cfzst``. See :ref:`file-prefixes`.
+- ``--output-prefix <prefix>`` Prefix to be added to calibrated spectrum.
 - ``--extraction <method>`` Select the :ref:`extraction-methods`. The only one
   implemented at the moment is ``fractional`` .
+- ``--fit-targets-with {moffat, gaussian}`` Model to fit peaks on spatial profile
+  while searching for spectroscopic targets.
+- ``--target-min-width <target min width>`` Minimum profile width for fitting the spatial axis of spectroscopic targets.
+  If fitting a Moffat it will be reflected as the FWHM attribute of the fitted model and if fitting a Gaussian it will
+  be reflected as the STDDEV attribute of the Gaussian model.
+- ``--target-max-width <target max width>`` Maximum profile width for fitting the spatial axis of spectroscopic targets.
+  If fitting a Moffat it will be reflected as the FWHM attribute of the fitted model and if fitting a Gaussian it will
+  be reflected as the STDDEV attribute of the Gaussian model.
 - ``--reference-files <path>`` Folder where to find the reference lamps.
 - ``--debug`` Shows extended and more messages.
 - ``--debug-plot`` Shows plots of intermediate steps.
 - ``--max-targets <value>`` Maximum number of targets to detect in a single
   image. Default is 3.
+- ``--background-threshold <background threshold>`` Multiplier for background level used to discriminate usable targets.
+  Default 3 times background level.
 - ``--save-plots`` Save plots.
 - ``--plot-results`` Show plots during execution.
 

--- a/docs/change_history.rst
+++ b/docs/change_history.rst
@@ -1,6 +1,15 @@
 Change History
 ##############
 
+.. _v1.3.5:
+
+V1.3.5 Not Released
+^^^^^^^^^^^^^^^^^^^
+
+- Created `--target-min-width` and `--target-max-width` flags to allow extraction of extended sources.
+- Replaced coveralls with codecov for code coverage.
+- Documentation improvements and updates.
+
 .. _v1.3.4:
 
 V1.3.4 11-05-2021
@@ -35,8 +44,8 @@ V1.3.1 23-09-2020
 
 - Documentation improvements:
 
-  + More docstrings
-  + New `File Suffixes`_ section
+  + More docstrings.
+  + New :ref:`file-suffixes` section.
 
 - Added more test code.
 - Cleaned .travis.yml and created special dcr installation script for travis.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -19,8 +19,16 @@ Welcome to the Goodman HTS Pipeline Documentation
 .. image:: https://readthedocs.org/projects/goodman/badge/?version=latest
     :target: http://goodman.readthedocs.io/en/latest/?badge=latest
     :alt: Documentation Status
+.. image:: https://img.shields.io/pypi/v/goodman_pipeline.svg?style=flat
+    :target: https://pypi.org/project/goodman-pipeline/
 .. image:: http://img.shields.io/badge/powered%20by-AstroPy-orange.svg?style=flat
     :target: http://www.astropy.org/
+
+
+.. image:: https://img.shields.io/lgtm/alerts/g/soar-telescope/goodman_pipeline.svg?logo=lgtm&logoWidth=18
+    :target: https://lgtm.com/projects/g/soar-telescope/goodman_pipeline/alerts/
+.. image:: https://img.shields.io/lgtm/grade/python/g/soar-telescope/goodman_pipeline.svg?logo=lgtm&logoWidth=18
+    :target: https://lgtm.com/projects/g/soar-telescope/goodman_pipeline/context:python
 
 This is the User Manual for the *Goodman Spectroscopic Data Reduction
 Pipeline*. It provides an overview of the pipeline's main features,

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -14,8 +14,8 @@ Welcome to the Goodman HTS Pipeline Documentation
 
 .. image:: https://github.com/soar-telescope/goodman_pipeline/workflows/Goodman%20Pipeline/badge.svg?branch=master
     :alt: Goodman Pipeline
-.. image:: https://coveralls.io/repos/github/soar-telescope/goodman_pipeline/badge.svg?branch=master
-    :target: https://coveralls.io/github/soar-telescope/goodman_pipeline?branch=master
+.. image:: https://codecov.io/gh/soar-telescope/goodman_pipeline/branch/main/graph/badge.svg
+    :target: https://codecov.io/gh/soar-telescope/goodman_pipeline
 .. image:: https://readthedocs.org/projects/goodman/badge/?version=latest
     :target: http://goodman.readthedocs.io/en/latest/?badge=latest
     :alt: Documentation Status

--- a/goodman_pipeline/core/core.py
+++ b/goodman_pipeline/core/core.py
@@ -4670,7 +4670,9 @@ class IdentifySpectroscopicTargets(object):
                 selected_peaks=selected_peaks,
                 order=order,
                 file_name=file_name,
-                plots=plots or self.plots)
+                plots=plots or self.plots,
+                stddev_min=self.profile_min_width,
+                stddev_max=self.profile_max_width)
             return self.profile_model
 
         if model_name == 'moffat':
@@ -4680,7 +4682,9 @@ class IdentifySpectroscopicTargets(object):
                 selected_peaks=selected_peaks,
                 order=order,
                 file_name=file_name,
-                plots=plots or self.plots)
+                plots=plots or self.plots,
+                fwhm_min=self.profile_min_width,
+                fwhm_max=self.profile_max_width)
             return self.profile_model
 
     @staticmethod
@@ -4696,10 +4700,12 @@ class IdentifySpectroscopicTargets(object):
         profile_model = []
         if stddev_min is None:
             stddev_min = 0
-            log.debug(f"Setting STDDEV minimum value to {stddev_min}. Set it with `--profile-min-width`.")
+            log.debug(f"Setting STDDEV minimum value to {stddev_min} pixels. Set it with `--profile-min-width`.")
         if stddev_max is None:
             stddev_max = 4 * order
-            log.debug(f"Setting STDDEV maximum value to {stddev_max}. Set it with `--profile-max-width`.")
+            log.debug(f"Setting STDDEV maximum value to {stddev_max} pixels. Set it with `--profile-max-width`.")
+        log.debug(f"Using minimum STDDEV = {stddev_min} pixels.")
+        log.debug(f"Using maximum STDDEV = {stddev_max} pixels.")
         for peak in selected_peaks:
             peak_value = spatial_profile[peak]
             gaussian = models.Gaussian1D(amplitude=peak_value,
@@ -4757,10 +4763,12 @@ class IdentifySpectroscopicTargets(object):
         log.info("Fitting 'Moffat1D' to spatial profile of targets.")
         if fwhm_min is None:
             fwhm_min = 0.5 * order
-            log.debug(f"Setting FWHM minimum value to {fwhm_min}. Set it with `--profile-min-width`.")
+            log.debug(f"Setting FWHM minimum value to {fwhm_min} pixels. Set it with `--profile-min-width`.")
         if fwhm_max is None:
             fwhm_max = 4 * order
-            log.debug(f"Setting FWHM maximum value to {fwhm_max}. Set it with `--profile-max-width`.")
+            log.debug(f"Setting FWHM maximum value to {fwhm_max} pixels. Set it with `--profile-max-width`.")
+        log.debug(f"Using minimum FWHM = {fwhm_min} pixels.")
+        log.debug(f"Using maximum FWHM = {fwhm_max} pixels.")
         profile_model = []
         for peak in selected_peaks:
             peak_value = spatial_profile[peak]

--- a/goodman_pipeline/core/core.py
+++ b/goodman_pipeline/core/core.py
@@ -1916,6 +1916,8 @@ def identify_targets(ccd,
                      fit_model,
                      background_threshold,
                      nfind=3,
+                     profile_min_width=None,
+                     profile_max_width=None,
                      plots=False):
     """Identify Spectroscopic Targets
 
@@ -1928,6 +1930,8 @@ def identify_targets(ccd,
         discrimination.
         nfind (int): Maximum number of targets passing the background threshold
         to be returned, they are order from most intense peak to least intense.
+        profile_min_width (float): Minimum FWHM (moffat) or STDDEV (gaussian) for spatial profile model.
+        profile_max_width (float): Maximum FWHM (moffat) or STDDEV (gaussian) for spatial profile model.
         plots (bool): Flat for plotting results.
 
     Returns:
@@ -1940,6 +1944,8 @@ def identify_targets(ccd,
                                   nfind=nfind,
                                   background_threshold=background_threshold,
                                   model_name=fit_model,
+                                  profile_min_width=profile_min_width,
+                                  profile_max_width=profile_max_width,
                                   plots=plots)
 
     return identified_targets
@@ -4218,6 +4224,8 @@ class IdentifySpectroscopicTargets(object):
         self.plots = False
         self.background_threshold = 3
         self.profile_model = []
+        self.profile_min_width = None
+        self.profile_max_width = None
         self.model_name = None
         self.ccd = None
         self.slit_size = None
@@ -4235,6 +4243,8 @@ class IdentifySpectroscopicTargets(object):
                  nfind=3,
                  background_threshold=3,
                  model_name='gaussian',
+                 profile_min_width=None,
+                 profile_max_width=None,
                  plots=False):
         assert isinstance(ccd, ccdproc.CCDData)
         assert ccd.header['OBSTYPE'] in ['OBJECT', 'SPECTRUM'], \
@@ -4250,6 +4260,8 @@ class IdentifySpectroscopicTargets(object):
         self.plots = plots
         self.model_name = model_name
         self.background_threshold = background_threshold
+        self.profile_min_width = profile_min_width
+        self.profile_max_width = profile_max_width
 
         self.slit_size = re.sub('[a-zA-Z"_*]', '', self.ccd.header['SLIT'])
         log.debug('Slit size: {:s}'.format(self.slit_size))
@@ -4677,9 +4689,17 @@ class IdentifySpectroscopicTargets(object):
                       selected_peaks,
                       order,
                       file_name,
-                      plots):
+                      plots,
+                      stddev_min=None,
+                      stddev_max=None):
         log.info("Fitting 'Gaussian1D' to spatial profile of targets.")
         profile_model = []
+        if stddev_min is None:
+            stddev_min = 0
+            log.debug(f"Setting STDDEV minimum value to {stddev_min}. Set it with `--profile-min-width`.")
+        if stddev_max is None:
+            stddev_max = 4 * order
+            log.debug(f"Setting STDDEV maximum value to {stddev_max}. Set it with `--profile-max-width`.")
         for peak in selected_peaks:
             peak_value = spatial_profile[peak]
             gaussian = models.Gaussian1D(amplitude=peak_value,
@@ -4692,16 +4712,17 @@ class IdentifySpectroscopicTargets(object):
                                      spatial_profile)
 
             # this ensures the profile returned are valid
-            if (fitted_gaussian.stddev.value > 0) and \
-                    (fitted_gaussian.stddev.value < 4 * order):
+            if (fitted_gaussian.stddev.value > stddev_min) and \
+                    (fitted_gaussian.stddev.value < stddev_max):
                 profile_model.append(fitted_gaussian)
                 log.info(
                     "Recording target centered at: {:.2f}, stddev: {:.2f}"
                     "".format(fitted_gaussian.mean.value,
                               fitted_gaussian.stddev.value))
             else:
-                log.error("Discarding target with stddev: {:.3f}".format(
-                    fitted_gaussian.stddev.value))
+                log.error(f"Discarding target with stddev: {fitted_gaussian.stddev.value}. "
+                          f"Outside of limits {stddev_min} - {stddev_max}. Set new limits with "
+                          f"`--profile-min-width` and `--profile-max-width`")
 
         if plots:  # pragma: no cover
             fig, ax = plt.subplots()
@@ -4730,8 +4751,16 @@ class IdentifySpectroscopicTargets(object):
                     selected_peaks,
                     order,
                     file_name,
-                    plots):
+                    plots,
+                    fwhm_min=None,
+                    fwhm_max=None):
         log.info("Fitting 'Moffat1D' to spatial profile of targets.")
+        if fwhm_min is None:
+            fwhm_min = 0.5 * order
+            log.debug(f"Setting FWHM minimum value to {fwhm_min}. Set it with `--profile-min-width`.")
+        if fwhm_max is None:
+            fwhm_max = 4 * order
+            log.debug(f"Setting FWHM maximum value to {fwhm_max}. Set it with `--profile-max-width`.")
         profile_model = []
         for peak in selected_peaks:
             peak_value = spatial_profile[peak]
@@ -4745,8 +4774,8 @@ class IdentifySpectroscopicTargets(object):
                                    spatial_profile)
 
             # this ensures the profile returned are valid
-            if (fitted_moffat.fwhm > 0.5 * order) and \
-                    (fitted_moffat.fwhm < 4 * order):
+            if (fitted_moffat.fwhm > fwhm_min) and \
+                    (fitted_moffat.fwhm < fwhm_max):
                 profile_model.append(fitted_moffat)
                 log.info(
                     "Recording target centered at: {:.2f}, fwhm: {:.2f}"
@@ -4757,12 +4786,12 @@ class IdentifySpectroscopicTargets(object):
                     fitted_moffat.x_0.value))
                 if fitted_moffat.fwhm < 0:
                     log.error("Moffat model FWHM is negative")
-                elif 0 <= fitted_moffat.fwhm < 0.5 * order:
-                    log.error("Moffat model FWHM is too small: {:.3f}, most "
-                              "likely is an artifact".format(fitted_moffat.fwhm))
+                elif 0 <= fitted_moffat.fwhm < fwhm_min:
+                    log.error(f"Moffat model FWHM is too small: {fitted_moffat.fwhm}. "
+                              "Set a minimum limit with `--profile-min-width`.")
                 else:
-                    log.error("Moffat model FWHM too large: {:.3f}"
-                              "".format(fitted_moffat.fwhm))
+                    log.error(f"Moffat model FWHM is {fitted_moffat.fwhm}, larger than  current limit {fwhm_max}. "
+                              f"Set a maximum limit with `--profile-max-width`.")
 
         if plots:  # pragma: no cover
             fig, ax = plt.subplots()

--- a/goodman_pipeline/core/core.py
+++ b/goodman_pipeline/core/core.py
@@ -4722,11 +4722,11 @@ class IdentifySpectroscopicTargets(object):
                     (fitted_gaussian.stddev.value < stddev_max):
                 profile_model.append(fitted_gaussian)
                 log.info(
-                    "Recording target centered at: {:.2f}, stddev: {:.2f}"
+                    "Recording target centered at: {:.2f}, STDDEV: {:.2f}"
                     "".format(fitted_gaussian.mean.value,
                               fitted_gaussian.stddev.value))
             else:
-                log.error(f"Discarding target with stddev: {fitted_gaussian.stddev.value}. "
+                log.error(f"Discarding target with STDDEV: {fitted_gaussian.stddev.value}. "
                           f"Outside of limits {stddev_min} - {stddev_max}. Set new limits with "
                           f"`--profile-min-width` and `--profile-max-width`")
 
@@ -4763,10 +4763,10 @@ class IdentifySpectroscopicTargets(object):
         log.info("Fitting 'Moffat1D' to spatial profile of targets.")
         if fwhm_min is None:
             fwhm_min = 0.5 * order
-            log.debug(f"Setting FWHM minimum value to {fwhm_min} pixels. Set it with `--profile-min-width`.")
+            log.debug(f"Setting FWHM minimum value to {fwhm_min} pixels. Set it with `--target-min-width`.")
         if fwhm_max is None:
             fwhm_max = 4 * order
-            log.debug(f"Setting FWHM maximum value to {fwhm_max} pixels. Set it with `--profile-max-width`.")
+            log.debug(f"Setting FWHM maximum value to {fwhm_max} pixels. Set it with `--target-max-width`.")
         log.debug(f"Using minimum FWHM = {fwhm_min} pixels.")
         log.debug(f"Using maximum FWHM = {fwhm_max} pixels.")
         profile_model = []
@@ -4786,7 +4786,7 @@ class IdentifySpectroscopicTargets(object):
                     (fitted_moffat.fwhm < fwhm_max):
                 profile_model.append(fitted_moffat)
                 log.info(
-                    "Recording target centered at: {:.2f}, fwhm: {:.2f}"
+                    "Recording target centered at: {:.2f}, FWHM: {:.2f}"
                     "".format(fitted_moffat.x_0.value,
                               fitted_moffat.fwhm))
             else:

--- a/goodman_pipeline/spectroscopy/redspec.py
+++ b/goodman_pipeline/spectroscopy/redspec.py
@@ -119,6 +119,23 @@ def get_args(arguments=None):
                         choices=['moffat', 'gaussian'],
                         help="Model to fit peaks found on spatial profile "
                              "while searching for spectroscopic targets.")
+    parser.add_argument('--target-min-width',
+                        action='store',
+                        # default=0.,
+                        type=float,
+                        dest='target_min_width',
+                        help="Minimum profile width for fitting the spatial axis of spectroscopic targets. If fitting "
+                             "a Moffat it will be reflected as the FWHM attribute of the fitted model and if fitting a "
+                             "Gaussian it will be reflected as the STDDEV attribute of the Gaussian model.")
+
+    parser.add_argument('--target-max-width',
+                        action='store',
+                        # default=0.,
+                        type=float,
+                        dest='target_max_width',
+                        help="Maximum profile width for fitting the spatial axis of spectroscopic targets. If fitting "
+                             "a Moffat it will be reflected as the FWHM attribute of the fitted model and if fitting a "
+                             "Gaussian it will be reflected as the STDDEV attribute of the Gaussian model.")
 
     parser.add_argument('--reference-files',
                         action='store',
@@ -389,6 +406,8 @@ class MainApp(object):
                         fit_model=target_fit_model,
                         background_threshold=background_threshold,
                         nfind=self.args.max_n_targets,
+                        profile_min_width=self.args.target_min_width,
+                        profile_max_width=self.args.target_max_width,
                         plots=self.args.debug_with_plots)
 
                     # trace

--- a/goodman_pipeline/spectroscopy/wavelength.py
+++ b/goodman_pipeline/spectroscopy/wavelength.py
@@ -378,6 +378,14 @@ class WavelengthCalibration(object):
             compared=self.lamp.data,
             slit_size=slit_size,
             serial_binning=self.serial_binning)
+        log.debug(f"Found global cross-correlation value of: {global_cross_corr}")
+
+        if plots:
+            plt.title(f"Comparison of New to Reference Lamp\nGlobal Cross Correlation Value: {global_cross_corr}")
+            plt.plot(reference_lamp_ccd.data, label='Reference Lamp')
+            plt.plot(self.lamp.data, label='New Lamp')
+            plt.legend(loc='best')
+            plt.show()
 
         half_width = np.max(
             [int((len(self.lamp.data) / float(len(lamp_lines_pixel)))),
@@ -409,9 +417,7 @@ class WavelengthCalibration(object):
                 slit_size=slit_size,
                 serial_binning=self.serial_binning)
 
-            log.debug('Cross correlation value '
-                      '{:s} vs {:s}'.format(str(global_cross_corr),
-                                            str(correlation_value)))
+            log.debug(f"Cross correlation value {correlation_value} vs Global Reference value: {global_cross_corr}")
 
             if - corr_tolerance < (global_cross_corr - correlation_value) < \
                     corr_tolerance:

--- a/goodman_pipeline/version.py
+++ b/goodman_pipeline/version.py
@@ -1,2 +1,2 @@
 # This is an automatic generated file please do not edit
-__version__ = '1.3.4'
+__version__ = '1.3.5.dev1'

--- a/goodman_pipeline/version.py
+++ b/goodman_pipeline/version.py
@@ -1,2 +1,2 @@
 # This is an automatic generated file please do not edit
-__version__ = '1.3.5.dev1'
+__version__ = '1.3.5.dev2'

--- a/setup.cfg
+++ b/setup.cfg
@@ -32,4 +32,4 @@ install_requires =
     ccdproc
     astroplan
 # version should be PEP440 compatible (http://www.python.org/dev/peps/pep-0440)
-version = 1.3.5.dev1
+version = 1.3.5.dev2

--- a/setup.cfg
+++ b/setup.cfg
@@ -32,4 +32,4 @@ install_requires =
     ccdproc
     astroplan
 # version should be PEP440 compatible (http://www.python.org/dev/peps/pep-0440)
-version = 1.3.4
+version = 1.3.5.dev1


### PR DESCRIPTION
Will allow the user to adjust the limits for targets discrimination with the arguments

`--target-min-width` and `--target-max-width`

- If the model to be fitted to the spatial profile is `Moffat` it will translate as the FWHM of the moffat model
- If the model to be fitted is `Gaussian` it will translate to the STDDEV of the gaussian model.

- [x] Update documentation