### PR TITLE
process imaging data taken with FILTER2

### DIFF
--- a/goodman_pipeline/core/core.py
+++ b/goodman_pipeline/core/core.py
@@ -2319,7 +2319,13 @@ def name_master_flats(header,
                             + '.fits'
 
     elif technique == 'Imaging':
-        flat_filter = re.sub('[- ]', '_', header['FILTER'])
+        if header['FILTER'] != 'NO_FILTER':
+            flat_filter = header['FILTER']
+        elif header['FILTER2'] != 'NO_FILTER':
+            flat_filter = header['FILTER2']
+        else:
+            flat_filter = "NO_FILTER"
+        flat_filter = re.sub('[- ]', '_', flat_filter)
         flat_filter = re.sub('[<> ]', '', flat_filter)
         master_flat_name += '_' + flat_filter + dome_sky + '.fits'
 

--- a/goodman_pipeline/images/night_organizer.py
+++ b/goodman_pipeline/images/night_organizer.py
@@ -399,13 +399,14 @@ class NightOrganizer(object):
         # confs stands for configurations
         confs = flat_data.groupby(
             ['object',
-             'filter']).size().reset_index().rename(columns={0: 'count'})
+             'filter', 'filter2']).size().reset_index().rename(columns={0: 'count'})
 
         for i in confs.index:
 
             flat_group = flat_data[
                 ((flat_data['object'] == confs.iloc[i]['object']) &
-                 (flat_data['filter'] == confs.iloc[i]['filter']))]
+                 (flat_data['filter'] == confs.iloc[i]['filter']) &
+                 (flat_data['filter2'] == confs.iloc[i]['filter2']))]
 
             self.data_container.add_day_flats(flat_group)
 
@@ -417,12 +418,14 @@ class NightOrganizer(object):
         # confs stands for configurations
         confs = science_data.groupby(
             ['object',
-             'filter']).size().reset_index().rename(columns={0: 'count'})
+             'filter',
+             'filter2']).size().reset_index().rename(columns={0: 'count'})
 
         for i in confs.index:
 
             science_group = science_data[
                 ((science_data['object'] == confs.iloc[i]['object']) &
-                 (science_data['filter'] == confs.iloc[i]['filter']))]
+                 (science_data['filter'] == confs.iloc[i]['filter']) &
+                 (science_data['filter2'] == confs.iloc[i]['filter2']))]
 
             self.data_container.add_data_group(science_group)


### PR DESCRIPTION
Hi,

I recently got imaging data with the Goodman HTS using the stromgren bvy, Bessel BV, and Cousins Rc filters. The Bessel and Cousins filters are located in the second filter wheel and therefore populate the FILTER2 keyword in the FITS headers. The data pipeline is producing master flats correctly for the stromgren filters as it's looking for the FILTER keyword (line 2322 of core.py) but it's completely ignoring FILTER2. So the flats for the Bessel and Cousins filters are named "master_flat_NO_FILTER_dome.fits". Since there are three such filters in our dataset, it's producing three files but overwriting them as they're all named the same. 

At the same time, the night classifier is ignoring FILTER2 when grouping files. This is causing the B,V and Rc data to be grouped together and in tandem with the aforementioned issue, is matching them with the wrong master flats.

I have a quick fix for this issue in this pull request. Please review and let me know if you require any other modifications.

Thanks,
Sunil