### PR TITLE
Remove 'o' prefix

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -11,7 +11,6 @@ sphinx:
 formats: all
 
 python:
-    version: "3.12"
     install:
         - method: pip
           path: .

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,5 +1,10 @@
 version: 2
 
+build:
+  os: ubuntu-lts-latest
+  tools:
+    python: "3.12"
+    
 sphinx:
     configuration: docs/conf.py
 

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -4,14 +4,14 @@ build:
   os: ubuntu-lts-latest
   tools:
     python: "3.12"
-    
+
 sphinx:
     configuration: docs/conf.py
 
 formats: all
 
 python:
-    version: 3.8
+    version: "3.12"
     install:
         - method: pip
           path: .

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -3,7 +3,8 @@ version: 2
 build:
   os: ubuntu-lts-latest
   tools:
-    python: "3.12"
+    python: "mambaforge-22.9"
+
 
 sphinx:
     configuration: docs/conf.py

--- a/docs/_file_prefixes.rst
+++ b/docs/_file_prefixes.rst
@@ -45,19 +45,15 @@ So what does all those letter mean? Here is a table to explain it.
 
 So, for an original file named ``file.fits``:
 
-  ``o_file.fits``
-
-Means the file have been overscan corrected while
-
-  ``eczsto_file.fits``
+  ``eczst_file.fits``
 
 Means the spectrum has been extracted to a 1D  file but the file has not been
 flat fielded (``f`` missing).
 
 Ideally after running ``redccd`` the file should be named:
 
-  ``cfzsto_file.fits``
+  ``cfzst_file.fits``
 
 And after running ``redspec``:
 
-  ``wecfzsto_file.fits``
+  ``wecfzst_file.fits``


### PR DESCRIPTION
The overscan correction is no longer applied, so the `o` prefix is not longer in the documentation because it was confusing for the users.