### PR TITLE
Add background extraction controls

### DIFF
--- a/docs/_running_redccd.rst
+++ b/docs/_running_redccd.rst
@@ -48,18 +48,15 @@ A summary of the most important *command line arguments* are presented below.
 - ``--ignore-flats`` Ignores the existence or lack of ``FLAT`` data.
 - ``--raw-path <path>`` Set the directory where the raw data is located, can be relative.
 - ``--red-path <path>`` Set the directory where the reduced data will be stored. Default ``RED``.
-- ``--saturation <saturation>`` Set the saturation threshold in percentage. There
+- ``--saturation-threshold <saturation>`` Set the saturation threshold in percentage. There
   is a table with all the readout modes and their values at which saturation is
   reached, then all the pixels exceeding that value are counted. If the percentage
   is larger that the threshold defined with this argument the flat is marked as
   saturated. The default value is 1 percent.
+- ``--dcr-par-dir`` Directory where to look for a `dcr.par` file.
+- ``--skip-slit-trim`` Do not apply slit trimming.
+- ``--keep-cosmic-files``   After cleaning cosmic rays with `dcr`, do not remove the input file and the cosmic rays file. For 'lacosmic' it saves the mask to a fits file.
 
 
 This is intended to work with *spectroscopic* and *imaging* data, that it is why
 the process is split in two.
-
-
-
-
-
-

--- a/docs/_running_redspec.rst
+++ b/docs/_running_redspec.rst
@@ -32,7 +32,10 @@ behavior for every user or science case, we have implemented a set of
 - ``--output-prefix <prefix>`` Prefix to be added to calibrated spectrum. Default is
   ``w-``. See :ref:`file-prefixes`.
 - ``--extraction <method>`` Select the :ref:`extraction-methods`. The only one
-  implemented at the moment is ``fractional`` .
+  implemented at the moment is ``fractional``.
+- ``--extraction-width <value>`` Width of the extraction area as a function of target's spatial
+  profile FWHM. For instance if `extraction_with` is set to 1 the extracted area is 0.5 to each
+  side from the center of the traced target. Default 2.
 - ``--fit-targets-with {moffat, gaussian}`` Model to fit peaks on spatial profile
   while searching for spectroscopic targets. Default ``moffat``.
 - ``--target-min-width <target min width>`` Minimum profile width for fitting the spatial axis of spectroscopic targets.
@@ -44,10 +47,15 @@ behavior for every user or science case, we have implemented a set of
 - ``--reference-files <path>`` Folder where to find the reference lamps.
 - ``--debug`` Shows extended and more messages.
 - ``--debug-plot`` Shows plots of intermediate steps.
-- ``--max-targets <value>`` Maximum number of targets to detect in a single
-  image. Default is 3.
+- ``--max-targets <value>`` Maximum number of targets to detect in a single image. Default is 3.
+- ``--disable-background-extraction`` Disable background extraction.
 - ``--background-threshold <background threshold>`` Multiplier for background level used to discriminate usable targets.
   Default 3 times background level.
+- ``--background-spacing-factor <value>`` Number of target's spatial profile standard deviations to
+  separate the target extraction to the background. This is from the edge of the extraction zone to
+  the edge of the background region. Default 3.
+- ``--line-detection-threshold [0-100]`` Percent of peak value used to get line detection threshold.
+  The final value is calculated as minimum + 'percent of maximum'. Default value is 3.
 - ``--save-plots`` Save plots.
 - ``--plot-results`` Show plots during execution.
 

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -14,6 +14,10 @@ so that users can follow the steps and end up with a running version of the pipe
   visiting `<https://www.anaconda.com/download/>`_ for downloading
   the Anaconda installer for either operating system.
 
+.. warning::
+
+  For most cases doing ``pip install goodman-pipeline`` is enough. You just might need to compile DCR.
+
 Ubuntu
 ******
 
@@ -119,13 +123,10 @@ Common Steps
       File 'dcr.par' must be present in the working directory.
           ~~~~~~
 
-8. Run tests.
 
-  ``python setup.py test``
+8. Install the pipeline
 
-9. Install the pipeline
-
-  ``python setup.py install``
+  ``python -m pip install .``
 
 Using pip
 *********

--- a/goodman_pipeline/core/tests/test_core.py
+++ b/goodman_pipeline/core/tests/test_core.py
@@ -877,7 +877,7 @@ class ExtractionTest(TestCase):
             target_trace=self.target_trace,
             target_fwhm=self.target_profile_gaussian.fwhm,
             extraction_width=self.n_stddev,
-            background_spacing=self.distance)
+            background_spacing_factor=self.distance)
         # assert isinstance(fake_image, CCDData)
         self.assertIsInstance(extracted_array, CCDData)
 
@@ -892,7 +892,7 @@ class ExtractionTest(TestCase):
             target_trace=self.target_trace,
             target_fwhm=self.stddev,
             extraction_width=self.n_stddev,
-            background_spacing=self.distance)
+            background_spacing_factor=self.distance)
         # assert isinstance(fake_image, CCDData)
         self.assertIsInstance(extracted_array, CCDData)
 
@@ -923,7 +923,8 @@ class ExtractionTest(TestCase):
         extracted = extraction(ccd=self.fake_image,
                                target_trace=self.target_trace,
                                spatial_profile=self.target_profile_gaussian,
-                               extraction_name='fractional')
+                               extraction_name='fractional',
+                               background_spacing_factor=self.distance)
         self.assertIsInstance(extracted, CCDData)
         np.testing.assert_array_almost_equal(extracted, self.reference_result_gaussian)
 

--- a/goodman_pipeline/images/goodman_ccd.py
+++ b/goodman_pipeline/images/goodman_ccd.py
@@ -137,7 +137,7 @@ def get_args(arguments=None):
                         default='./RED',
                         help="Path to reduced data.")
 
-    parser.add_argument('--saturation_threshold',
+    parser.add_argument('--saturation-threshold',
                         action='store',
                         default=1.,
                         dest='saturation_threshold',

--- a/goodman_pipeline/images/tests/test_image_processor.py
+++ b/goodman_pipeline/images/tests/test_image_processor.py
@@ -14,7 +14,7 @@ import numpy as np
 class ImageProcessorTest(TestCase):
 
     def setUp(self):
-        arguments = ['--saturation_threshold', '1']
+        arguments = ['--saturation-threshold', '1']
         args = get_args(arguments=arguments)
         data_container = NightDataContainer(path='/fake',
                                             instrument='Red',

--- a/goodman_pipeline/spectroscopy/redspec.py
+++ b/goodman_pipeline/spectroscopy/redspec.py
@@ -112,6 +112,15 @@ def get_args(arguments=None):
                              "'optimal'. Only fractional pixel extraction is "
                              "implemented. Default 'fractional'.")
 
+    parser.add_argument('--extraction-width',
+                        action='store',
+                        dest='extraction_width',
+                        type=int,
+                        default=2,
+                        help="Width of the extraction area as a function of target's spatial profile FWHM. For instance "
+                             "if `extraction_with` is set to 1 the extracted area is 0.5 to each side from the center of "
+                             "the traced target. Default 2.")
+
     parser.add_argument('--fit-targets-with',
                         action='store',
                         default='moffat',
@@ -164,6 +173,11 @@ def get_args(arguments=None):
                         help="Maximum number of targets to be found in a "
                              "single image. Default 3")
 
+    parser.add_argument('--disable-background-extraction',
+                        action='store_true',
+                        dest='disable_background_extraction',
+                        help="Disable background extraction")
+
     parser.add_argument('--background-threshold',
                         action='store',
                         dest='background_threshold',
@@ -172,6 +186,15 @@ def get_args(arguments=None):
                         help="Multiplier for background level used to "
                              "discriminate usable targets. Default 3 times "
                              "background level")
+
+    parser.add_argument('--background-spacing-factor',
+                        action='store',
+                        dest='background_spacing_factor',
+                        type=float,
+                        default=3,
+                        help="Number of target's  spatial profile standard deviations to separate the target extraction "
+                             "to the background. This is from the edge of the extraction zone to the edge of "
+                             "the background region. Default 3.")
 
     parser.add_argument('--line-detection-threshold',
                         action='store',
@@ -456,7 +479,10 @@ class ReduceSpectroscopy(object):
                                 ccd=ccd,
                                 target_trace=single_trace,
                                 spatial_profile=single_profile,
-                                extraction_name=extraction_type)
+                                extraction_name=extraction_type,
+                                extraction_width=self.args.extraction_width,
+                                background_spacing_factor=self.args.background_spacing_factor,
+                                disable_background_extraction=self.args.disable_background_extraction)
 
                             saved_ccd = save_extracted(
                                 ccd=extracted,
@@ -480,7 +506,10 @@ class ReduceSpectroscopy(object):
                                         ccd=comp_lamp,
                                         target_trace=single_trace,
                                         spatial_profile=single_profile,
-                                        extraction_name=extraction_type)
+                                        extraction_name=extraction_type,
+                                        extraction_width=self.args.extraction_width,
+                                        background_spacing_factor=self.args.background_spacing_factor,
+                                        disable_background_extraction=self.args.disable_background_extraction)
                                     save_extracted(
                                         ccd=extracted_lamp,
                                         destination=self.args.destination,


### PR DESCRIPTION
Create the following new arguments:

- `--extraction-width EXTRACTION_WIDTH`
                        Width of the extraction area as a function of target's spatial profile FWHM. For instance if `extraction_with` is set to 1 the extracted area is 0.5 to each side from the center of the traced target. Default 2.
- `--disable-background-extraction`
                        Disable background extraction
- `--background-spacing-factor BACKGROUND_SPACING_FACTOR`
                        Number of target's spatial profile standard deviations to separate the target extraction to the background. This is from the edge of the extraction zone to the edge of the background region. Default 3.

Also updated the documentation.